### PR TITLE
Release v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.0.0] - 2024-02-05
 
 ### Added
 

--- a/wagtail_modeladmin/__init__.py
+++ b/wagtail_modeladmin/__init__.py
@@ -1,2 +1,2 @@
-VERSION = (1, 0, 0)
+VERSION = (2, 0, 0)
 __version__ = ".".join(map(str, VERSION))


### PR DESCRIPTION
Bumping the major version as we're dropping support for Django < 4.2 and Wagtail < 5.2.