### PR TITLE
feat: add support for adding modeladmin view to reports for WagtailRe…

### DIFF
--- a/wagtail_modeladmin/options.py
+++ b/wagtail_modeladmin/options.py
@@ -43,6 +43,7 @@ class WagtailRegisterable:
     """
 
     add_to_settings_menu = False
+    add_to_reports_menu = False
     add_to_admin_menu = True
     exclude_from_explorer = False
 
@@ -57,6 +58,8 @@ class WagtailRegisterable:
 
         if self.add_to_settings_menu:
             menu_hook = "register_settings_menu_item"
+        elif self.add_to_reports_menu:
+            menu_hook = "register_reports_menu_item"
         elif self.add_to_admin_menu:
             menu_hook = "register_admin_menu_item"
         else:


### PR DESCRIPTION
Resolving issue: [#42](https://github.com/wagtail-nest/wagtail-modeladmin/issues/42)

I've noticed that you can add ModelAdmin MenuItem to Settings menu, but you cannot add it to Reports menu. It required only a simple change, so I've implemented it already.

If the feature is about to be accepted, I'll add the amendments to the Docs.