### PR TITLE
Wagtail 64 upgrade

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ python =
     3.10 = python3.10-django{4.2,5.0}-wagtail{5.2,6.1,6.2,main}
     3.11 = python3.11-django{4.2,5.0}-wagtail{6.1,6.2,main}
     3.12 = python3.12-django{4.2,5.0}-wagtail{6.1,6.2,main}
-    3.13 = python3.13-django{5.1,main}-wagtail{6.3,6.4,main}
+    3.13 = python3.13-django{5.1}-wagtail{6.3,6.4,main}
 
 [testenv]
 install_command = pip install -e ".[testing]" -U {opts} {packages}

--- a/tox.ini
+++ b/tox.ini
@@ -3,9 +3,9 @@ skipsdist = True
 usedevelop = True
 
 envlist =
-    python{3.9,3.10,3.11}-django{4.2,5.0,main}-wagtail{5.2,6.1,6.2,main}
-    python{3.10,3.11,3.12}-django{5.0,main}-wagtail{5.2,6.1,6.2,main}
-    python3.13-django{5.1,main}-wagtail{6.3,main}
+    python{3.9,3.10,3.11}-django{4.2,5.0,main}-wagtail{5.2,6.1,6.2,6.3,6.4,main}
+    python{3.10,3.11,3.12}-django{5.0,main}-wagtail{5.2,6.1,6.2,6.3,6.4,main}
+    python3.13-django{5.1,main}-wagtail{6.3,6.4,main}
 
 [gh]
 python =
@@ -13,7 +13,7 @@ python =
     3.10 = python3.10-django{4.2,5.0}-wagtail{5.2,6.1,6.2,main}
     3.11 = python3.11-django{4.2,5.0}-wagtail{6.1,6.2,main}
     3.12 = python3.12-django{4.2,5.0}-wagtail{6.1,6.2,main}
-    3.13 = python3.13-django{5.1,main}-wagtail{6.3,main}
+    3.13 = python3.13-django{5.1,main}-wagtail{6.3,6.4,main}
 
 [testenv]
 install_command = pip install -e ".[testing]" -U {opts} {packages}
@@ -36,7 +36,8 @@ deps =
     wagtail5.2: wagtail>=5.2,<6.0
     wagtail6.1: wagtail>=6.1,<6.2
     wagtail6.2: wagtail>=6.2,<6.3
-    wagtail6.3: git+https://github.com/wagtail/wagtail.git@stable/6.3.x#egg=wagtail
+    wagtail6.3: wagtail>=6.3,<6.4
+    wagtail6.4: wagtail>=6.4,<6.5
     wagtailmain: git+https://github.com/wagtail/wagtail.git#egg=wagtail
 
     postgres: psycopg2>=2.8.4

--- a/wagtail_modeladmin/test/tests/test_simple_modeladmin.py
+++ b/wagtail_modeladmin/test/tests/test_simple_modeladmin.py
@@ -10,6 +10,7 @@ from django.test import TestCase, TransactionTestCase
 from django.test.utils import override_settings
 from django.utils.timezone import make_aware
 from openpyxl import load_workbook
+from wagtail import VERSION as WAGTAIL_VERSION
 from wagtail.admin.admin_url_finder import AdminURLFinder
 from wagtail.admin.panels import (
     FieldPanel,
@@ -1156,14 +1157,26 @@ class TestPanelConfigurationChecks(WagtailTestUtils, TestCase):
     def test_model_with_single_tabbed_panel_only(self):
         Publisher.content_panels = [FieldPanel("name"), FieldPanel("headquartered_in")]
 
-        warning = checks.Warning(
-            "Publisher.content_panels will have no effect on modeladmin editing",
-            hint="""Ensure that Publisher uses `panels` instead of `content_panels`\
+        warning = (
+            checks.Warning(
+                "Publisher.content_panels will have no effect on modeladmin editing",
+                hint="""Ensure that Publisher uses `panels` instead of `content_panels`\
+ or set up an `edit_handler` if you want a tabbed editing interface.
+There are no default tabs on non-Page models so there will be no\
+ Content tab for the content_panels to render in.""",
+                obj=Publisher,
+                id="wagtailadmin.W002",
+            )
+            if WAGTAIL_VERSION >= (6, 4)
+            else checks.Warning(
+                "Publisher.content_panels will have no effect on modeladmin editing",
+                hint="""Ensure that Publisher uses `panels` instead of `content_panels`\
 or set up an `edit_handler` if you want a tabbed editing interface.
 There are no default tabs on non-Page models so there will be no\
  Content tab for the content_panels to render in.""",
-            obj=Publisher,
-            id="wagtailadmin.W002",
+                obj=Publisher,
+                id="wagtailadmin.W002",
+            )
         )
 
         checks_results = self.get_checks_result()

--- a/wagtail_modeladmin/test/tests/test_simple_modeladmin.py
+++ b/wagtail_modeladmin/test/tests/test_simple_modeladmin.py
@@ -1190,24 +1190,48 @@ There are no default tabs on non-Page models so there will be no\
         Publisher.settings_panels = [FieldPanel("name")]
         Publisher.promote_panels = [FieldPanel("headquartered_in")]
 
-        warning_1 = checks.Warning(
-            "Publisher.promote_panels will have no effect on modeladmin editing",
-            hint="""Ensure that Publisher uses `panels` instead of `promote_panels`\
+        warning_1 = (
+            checks.Warning(
+                "Publisher.promote_panels will have no effect on modeladmin editing",
+                hint="""Ensure that Publisher uses `panels` instead of `promote_panels`\
+ or set up an `edit_handler` if you want a tabbed editing interface.
+There are no default tabs on non-Page models so there will be no\
+ Promote tab for the promote_panels to render in.""",
+                obj=Publisher,
+                id="wagtailadmin.W002",
+            )
+            if WAGTAIL_VERSION >= (6, 4)
+            else checks.Warning(
+                "Publisher.promote_panels will have no effect on modeladmin editing",
+                hint="""Ensure that Publisher uses `panels` instead of `promote_panels`\
 or set up an `edit_handler` if you want a tabbed editing interface.
 There are no default tabs on non-Page models so there will be no\
  Promote tab for the promote_panels to render in.""",
-            obj=Publisher,
-            id="wagtailadmin.W002",
+                obj=Publisher,
+                id="wagtailadmin.W002",
+            )
         )
 
-        warning_2 = checks.Warning(
-            "Publisher.settings_panels will have no effect on modeladmin editing",
-            hint="""Ensure that Publisher uses `panels` instead of `settings_panels`\
+        warning_2 = (
+            checks.Warning(
+                "Publisher.settings_panels will have no effect on modeladmin editing",
+                hint="""Ensure that Publisher uses `panels` instead of `settings_panels`\
+ or set up an `edit_handler` if you want a tabbed editing interface.
+There are no default tabs on non-Page models so there will be no\
+ Settings tab for the settings_panels to render in.""",
+                obj=Publisher,
+                id="wagtailadmin.W002",
+            )
+            if WAGTAIL_VERSION >= (6, 4)
+            else checks.Warning(
+                "Publisher.settings_panels will have no effect on modeladmin editing",
+                hint="""Ensure that Publisher uses `panels` instead of `settings_panels`\
 or set up an `edit_handler` if you want a tabbed editing interface.
 There are no default tabs on non-Page models so there will be no\
  Settings tab for the settings_panels to render in.""",
-            obj=Publisher,
-            id="wagtailadmin.W002",
+                obj=Publisher,
+                id="wagtailadmin.W002",
+            )
         )
 
         checks_results = self.get_checks_result()


### PR DESCRIPTION
This pull request includes several updates to the `tox.ini` configuration file and chnages to the test cases in `wagtail_modeladmin/test/tests/test_simple_modeladmin.py`. 

### Updates to `tox.ini`:

* Added Wagtail versions 6.3 and 6.4 to the testing matrix for various Python and Django versions.

### Enhancements to test cases:

* Added conditional logic in the `test_model_with_single_tabbed_panel_only` method to handle different warning messages based on the Wagtail version. 
* Added conditional logic in the `test_model_with_two_tabbed_panels_only` method to handle different warning messages based on the Wagtail version.