### PR TITLE
Wagtail 6.4 upgrade + Wagtail 7.0 deprecation fix

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,27 +9,22 @@ on:
 jobs:
   nightly-wagtail-test:
     runs-on: ubuntu-latest
-    env:
-      WEBHOOK_EXISTS: ${{ secrets.SLACK_WEBHOOK_URL != '' }}
-
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
-
-      - run: git clone https://github.com/wagtail/wagtail.git
-
-      - run: python -m pip install flit
-      - run: flit install --deps production --extras testing
-      - run: python -m pip install ./wagtail
-
-      - run: python testmanage.py test
-
-      - name: Report failure
+          python-version: '3.13'
+      - name: Install Tox
         run: |
-          python -m pip install requests
-          python ./.github/scripts/report_nightly_build_failure.py
-        if: ${{ failure() && env.WEBHOOK_EXISTS == 'true' }}
+          python -m pip install --upgrade pip setuptools wheel tox
+      - name: Run 'future' tests
+        id: test
+        continue-on-error: true
+        run: |
+          tox -e future
+      - name: 'On failure, report to #nightly-build-failures in Wagtail Slack'
+        if: steps.test.outcome == 'failure'
+        run: |
+          python .github/report_nightly_build_failure.py
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,8 +16,9 @@ permissions:
   contents: read # to fetch code (actions/checkout)
 
 jobs:
-  lint:
+  pre-commit:
     runs-on: ubuntu-latest
+    name: Run pre-commit hooks
     steps:
       - uses: actions/checkout@v4
         with:
@@ -30,7 +31,6 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
-    needs: lint
     strategy:
       matrix:
         python: ['3.9', '3.10', '3.11', '3.12', '3.13']

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
           python-version: '3.13'
       - uses: pre-commit/action@v3.0.1
 
-  test-sqlite:
+  test:
     runs-on: ubuntu-latest
     needs: lint
     strategy:
@@ -43,49 +43,8 @@ jobs:
           python-version: ${{ matrix.python }}
       - name: Install Tox
         run: |
-          python -m pip install --upgrade pip setuptools wheel
-          python -m pip install --upgrade tox-gh
-      - name: Setup test suite
-        run: tox -vv --notest
-      - name: Run test suite
-        run: tox --skip-pkg-install
-
-  test-postgres:
-    runs-on: ubuntu-latest
-    needs: lint
-    strategy:
-      matrix:
-        python: ['3.9', '3.10']
-        include:
-          - python: '3.11'
-            postgres: '12'
-          - python: '3.12'
-            postgres: '13'
-          - python: '3.13'
-            postgres: '17'
-
-    services:
-      postgres:
-        image: postgres:${{ matrix.postgres || '11' }}
-        env:
-          POSTGRES_PASSWORD: postgres
-        ports:
-          - 5432:5432
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
-
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python }}
-      - name: Install Tox
+          python -m pip install --upgrade pip setuptools wheel tox
+      - name: Run test suite for Python ${{ matrix.python }}
         run: |
-          python -m pip install --upgrade pip setuptools wheel
-          python -m pip install --upgrade tox-gh
-      - name: Setup test suite
-        run: tox -vv --notest
-      - name: Run test suite
-        run: tox --skip-pkg-install
-        env:
-          DATABASE_URL: postgres://postgres:postgres@localhost:5432/wagtail_modeladmin
+          # Run only the tox environments that match the Python version
+          tox run -f py$(echo ${{ matrix.python }} | tr -d .)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ default_language_version:
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v5.0.0
     hooks:
       - id: check-added-large-files
       - id: check-case-conflict
@@ -19,26 +19,26 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/psf/black
-    rev: 24.4.2
+    rev: 25.1.0
     hooks:
       - id: black
         language_version: python3
         args: ['--target-version', 'py38']
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     # Ruff version.
-    rev: 'v0.0.265'
+    rev: 'v0.11.5'
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
   - repo: https://github.com/pre-commit/mirrors-prettier
     # prettier config is in prettier.config.js
-    rev: 'v2.7.1'
+    rev: 'v4.0.0-alpha.8'
     hooks:
       - id: prettier
         types_or: [css, scss, javascript, json, yaml]
   - repo: https://github.com/pre-commit/mirrors-eslint
     # eslint config is in .eslintrc.js
-    rev: v8.40.0
+    rev: v9.24.0
     hooks:
       - id: eslint
         additional_dependencies:
@@ -55,7 +55,7 @@ repos:
         types: [file]
   - repo: https://github.com/thibaudcolas/pre-commit-stylelint
     # stylelint config is in .stylelintrc.js
-    rev: v15.6.1
+    rev: v16.18.0
     hooks:
       - id: stylelint
         files: \.(scss)$
@@ -63,7 +63,7 @@ repos:
           - 'stylelint@15.6.1'
           - '@wagtail/stylelint-config-wagtail@0.6.0'
   - repo: https://github.com/adamchainz/blacken-docs
-    rev: 1.16.0
+    rev: 1.19.1
     hooks:
       - id: blacken-docs
-        additional_dependencies: [black==24.4.2]
+        additional_dependencies: [black==25.1.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Wagtail 6.3 and 6.4 support
 - Django 5.2 support
+- Fix `RemovedInWagtail70Warning` deprecation warning about `classnames` kwarg usage when initializing `MenuItem`
 
 ## [2.1.0] - 2024-10-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.0] - [UNRELEASED]
+
+- Wagtail 6.3 and 6.4 support
+- Django 5.2 support
+
 ## [2.1.0] - 2024-10-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This package is in maintenance mode and will not receive new features. Consider 
 
 - Python 3.8 (Wagtail 5.2 only), 3.9, 3.10, 3.11, 3.12, 3.13
 - Django 4.2, 5.0, 5.1, 5.2
-- Wagtail 5.2, 6.1, 6.2, 6.3
+- Wagtail 5.2, 6.1, 6.2, 6.3 and 6.4
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This package is in maintenance mode and will not receive new features. Consider 
 ## Supported versions
 
 - Python 3.8 (Wagtail 5.2 only), 3.9, 3.10, 3.11, 3.12, 3.13
-- Django 4.2, 5.0, 5.1
+- Django 4.2, 5.0, 5.1, 5.2
 - Wagtail 5.2, 6.1, 6.2, 6.3
 
 ## Installation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
     "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.0",
     "Framework :: Django :: 5.1",
+    "Framework :: Django :: 5.2",
     "Framework :: Wagtail",
     "Framework :: Wagtail :: 5",
     "Framework :: Wagtail :: 6",

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ usedevelop = True
 envlist =
     python{3.9,3.10,3.11}-django{4.2,5.0,main}-wagtail{5.2,6.1,6.2,6.3,6.4,main}
     python{3.10,3.11,3.12}-django{5.0,main}-wagtail{5.2,6.1,6.2,6.3,6.4,main}
-    python3.13-django{5.1,main}-wagtail{6.3,6.4,main}
+    python3.13-django{5.1,5.2,main}-wagtail{6.3,6.4,main}
 
 [gh]
 python =
@@ -13,7 +13,7 @@ python =
     3.10 = python3.10-django{4.2,5.0}-wagtail{5.2,6.1,6.2,main}
     3.11 = python3.11-django{4.2,5.0}-wagtail{6.1,6.2,main}
     3.12 = python3.12-django{4.2,5.0}-wagtail{6.1,6.2,main}
-    3.13 = python3.13-django{5.1}-wagtail{6.3,6.4,main}
+    3.13 = python3.13-django{5.1,5.2}-wagtail{6.3,6.4,main}
 
 [testenv]
 install_command = pip install -e ".[testing]" -U {opts} {packages}
@@ -32,6 +32,7 @@ deps =
     django4.2: Django>=4.2,<4.3
     django5.0: Django>=5.0,<5.1
     django5.1: Django>=5.1,<5.2
+    django5.2: Django>=5.2,<5.3
     djangomain: git+https://github.com/django/django.git@main#egg=Django
 
     wagtail5.2: wagtail>=5.2,<6.0

--- a/tox.ini
+++ b/tox.ini
@@ -48,7 +48,7 @@ setenv =
     postgres: DATABASE_URL={env:DATABASE_URL:postgres:///wagtail_modeladmin}
 
 [testenv:interactive]
-basepython = python3.10
+basepython = python3.13
 
 commands_pre =
     python {toxinidir}/testmanage.py makemigrations

--- a/tox.ini
+++ b/tox.ini
@@ -1,51 +1,40 @@
 [tox]
-skipsdist = True
-usedevelop = True
-
+minversion = 4.18.1
 envlist =
-    python{3.9,3.10,3.11}-django{4.2,5.0,main}-wagtail{5.2,6.1,6.2,6.3,6.4,main}
-    python{3.10,3.11,3.12}-django{5.0,main}-wagtail{5.2,6.1,6.2,6.3,6.4,main}
-    python3.13-django{5.1,5.2,main}-wagtail{6.3,6.4,main}
-
-[gh]
-python =
-    3.9 = python3.9-django{4.2}-wagtail{5.2,main}
-    3.10 = python3.10-django{4.2,5.0}-wagtail{5.2,6.1,6.2,main}
-    3.11 = python3.11-django{4.2,5.0}-wagtail{6.1,6.2,main}
-    3.12 = python3.12-django{4.2,5.0}-wagtail{6.1,6.2,main}
-    3.13 = python3.13-django{5.1,5.2}-wagtail{6.3,6.4,main}
+    py{39,310,311,312}-django42-wagtail52
+    py{310,311,312}-django50-wagtail52
+    py{39,310,311,312}-django42-wagtail{63,64}
+    py{310,311,312}-django{50,51}-wagtail{63,64}
+    py313-django{51}-wagtail{63,64}
 
 [testenv]
-install_command = pip install -e ".[testing]" -U {opts} {packages}
+extras = testing
 commands = coverage run testmanage.py test --deprecation all {posargs: -v 2}
 
 basepython =
-    python3.9: python3.9
-    python3.10: python3.10
-    python3.11: python3.11
-    python3.12: python3.12
-    python3.13: python3.13
+    py39: python3.9
+    py310: python3.10
+    py311: python3.11
+    py312: python3.12
+    py313: python3.13
 
 deps =
     coverage
 
-    django4.2: Django>=4.2,<4.3
-    django5.0: Django>=5.0,<5.1
-    django5.1: Django>=5.1,<5.2
-    django5.2: Django>=5.2,<5.3
-    djangomain: git+https://github.com/django/django.git@main#egg=Django
+    django42: Django>=4.2,<4.3
+    django50: Django>=5.0,<5.1
+    django51: Django>=5.1,<5.2
+    django52: Django>=5.2,<5.3
 
-    wagtail5.2: wagtail>=5.2,<6.0
-    wagtail6.1: wagtail>=6.1,<6.2
-    wagtail6.2: wagtail>=6.2,<6.3
-    wagtail6.3: wagtail>=6.3,<6.4
-    wagtail6.4: wagtail>=6.4,<6.5
-    wagtailmain: git+https://github.com/wagtail/wagtail.git#egg=wagtail
+    wagtail52: wagtail>=5.2,<6.0
+    wagtail61: wagtail>=6.1,<6.2
+    wagtail62: wagtail>=6.2,<6.3
+    wagtail63: wagtail>=6.3,<6.4
+    wagtail64: wagtail>=6.4,<6.5
 
-    postgres: psycopg2>=2.8.4
 
-setenv =
-    postgres: DATABASE_URL={env:DATABASE_URL:postgres:///wagtail_modeladmin}
+
+
 
 [testenv:interactive]
 basepython = python3.13

--- a/tox.ini
+++ b/tox.ini
@@ -32,9 +32,15 @@ deps =
     wagtail63: wagtail>=6.3,<6.4
     wagtail64: wagtail>=6.4,<6.5
 
-
-
-
+[testenv:future]
+extras = testing
+commands = coverage run testmanage.py test --deprecation all {posargs: -v 2}
+basepython = python3.13
+deps =
+    coverage
+    ; Test compatibility with upcoming Wagtail and Django versions
+    https://github.com/wagtail/wagtail/archive/refs/heads/main.zip
+    https://github.com/django/django/archive/refs/heads/main.zip
 
 [testenv:interactive]
 basepython = python3.13

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ python =
     3.10 = python3.10-django{4.2,5.0}-wagtail{5.2,6.1,6.2,main}
     3.11 = python3.11-django{4.2,5.0}-wagtail{6.1,6.2,main}
     3.12 = python3.12-django{4.2,5.0}-wagtail{6.1,6.2,main}
-    3.13 = python3.13-django{5.1,main}-wagtail{6.3,6.4,main}
+    3.13 = python3.13-django{5.1}-wagtail{6.3,6.4,main}
 
 [testenv]
 install_command = pip install -e ".[testing]" -U {opts} {packages}

--- a/tox.ini
+++ b/tox.ini
@@ -3,9 +3,9 @@ skipsdist = True
 usedevelop = True
 
 envlist =
-    python{3.9,3.10,3.11}-django{4.2,5.0,main}-wagtail{5.2,6.1,6.2,main}
-    python{3.10,3.11,3.12}-django{5.0,main}-wagtail{5.2,6.1,6.2,main}
-    python3.13-django{5.1,main}-wagtail{6.3,main}
+    python{3.9,3.10,3.11}-django{4.2,5.0,main}-wagtail{5.2,6.1,6.2,6.3,6.4,main}
+    python{3.10,3.11,3.12}-django{5.0,main}-wagtail{5.2,6.1,6.2,6.3,6.4,main}
+    python3.13-django{5.1,main}-wagtail{6.3,6.4,main}
 
 [gh]
 python =
@@ -13,7 +13,7 @@ python =
     3.10 = python3.10-django{4.2,5.0}-wagtail{5.2,6.1,6.2,main}
     3.11 = python3.11-django{4.2,5.0}-wagtail{6.1,6.2,main}
     3.12 = python3.12-django{4.2,5.0}-wagtail{6.1,6.2,main}
-    3.13 = python3.13-django{5.1,main}-wagtail{6.3,main}
+    3.13 = python3.13-django{5.1,main}-wagtail{6.3,6.4,main}
 
 [testenv]
 install_command = pip install -e ".[testing]" -U {opts} {packages}
@@ -36,7 +36,8 @@ deps =
     wagtail5.2: wagtail>=5.2,<6.0
     wagtail6.1: wagtail>=6.1,<6.2
     wagtail6.2: wagtail>=6.2,<6.3
-    wagtail6.3: git+https://github.com/wagtail/wagtail.git@stable/6.3.x#egg=wagtail
+    wagtail6.3: wagtail>=6.3,<6.4
+    wagtail6.4: wagtail>=6.4,<6.5
     wagtailmain: git+https://github.com/wagtail/wagtail.git#egg=wagtail
 
     postgres: psycopg2>=2.8.4

--- a/tox.ini
+++ b/tox.ini
@@ -31,6 +31,7 @@ deps =
 
     django4.2: Django>=4.2,<4.3
     django5.0: Django>=5.0,<5.1
+    django5.1: Django>=5.1,<5.2
     djangomain: git+https://github.com/django/django.git@main#egg=Django
 
     wagtail5.2: wagtail>=5.2,<6.0

--- a/wagtail_modeladmin/menus.py
+++ b/wagtail_modeladmin/menus.py
@@ -12,16 +12,16 @@ class ModelAdminMenuItem(MenuItem):
         url = model_admin.url_helper.index_url
         menu_icon = model_admin.get_menu_icon()
         if menu_icon[:3] == "fa-":
-            classnames = "icon icon-%s" % menu_icon
+            classname = "icon icon-%s" % menu_icon
             icon_name = None
         else:
-            classnames = ""
+            classname = ""
             icon_name = menu_icon
         super().__init__(
             label=model_admin.get_menu_label(),
             url=url,
             name=model_admin.get_menu_item_name(),
-            classnames=classnames,
+            classname=classname,
             icon_name=icon_name,
             order=order,
         )
@@ -40,16 +40,16 @@ class GroupMenuItem(SubmenuMenuItem):
     def __init__(self, modeladmingroup, order, menu):
         menu_icon = modeladmingroup.get_menu_icon()
         if menu_icon[:3] == "fa-":
-            classnames = "icon icon-%s" % menu_icon
+            classname = "icon icon-%s" % menu_icon
             icon_name = None
         else:
-            classnames = ""
+            classname = ""
             icon_name = menu_icon
         super().__init__(
             label=modeladmingroup.get_menu_label(),
             menu=menu,
             name=modeladmingroup.get_menu_item_name(),
-            classnames=classnames,
+            classname=classname,
             icon_name=icon_name,
             order=order,
         )

--- a/wagtail_modeladmin/test/tests/test_simple_modeladmin.py
+++ b/wagtail_modeladmin/test/tests/test_simple_modeladmin.py
@@ -10,6 +10,7 @@ from django.test import TestCase, TransactionTestCase
 from django.test.utils import override_settings
 from django.utils.timezone import make_aware
 from openpyxl import load_workbook
+from wagtail import VERSION as WAGTAIL_VERSION
 from wagtail.admin.admin_url_finder import AdminURLFinder
 from wagtail.admin.panels import (
     FieldPanel,
@@ -1156,14 +1157,26 @@ class TestPanelConfigurationChecks(WagtailTestUtils, TestCase):
     def test_model_with_single_tabbed_panel_only(self):
         Publisher.content_panels = [FieldPanel("name"), FieldPanel("headquartered_in")]
 
-        warning = checks.Warning(
-            "Publisher.content_panels will have no effect on modeladmin editing",
-            hint="""Ensure that Publisher uses `panels` instead of `content_panels`\
+        warning = (
+            checks.Warning(
+                "Publisher.content_panels will have no effect on modeladmin editing",
+                hint="""Ensure that Publisher uses `panels` instead of `content_panels`\
+ or set up an `edit_handler` if you want a tabbed editing interface.
+There are no default tabs on non-Page models so there will be no\
+ Content tab for the content_panels to render in.""",
+                obj=Publisher,
+                id="wagtailadmin.W002",
+            )
+            if WAGTAIL_VERSION >= (6, 4)
+            else checks.Warning(
+                "Publisher.content_panels will have no effect on modeladmin editing",
+                hint="""Ensure that Publisher uses `panels` instead of `content_panels`\
 or set up an `edit_handler` if you want a tabbed editing interface.
 There are no default tabs on non-Page models so there will be no\
  Content tab for the content_panels to render in.""",
-            obj=Publisher,
-            id="wagtailadmin.W002",
+                obj=Publisher,
+                id="wagtailadmin.W002",
+            )
         )
 
         checks_results = self.get_checks_result()

--- a/wagtail_modeladmin/test/tests/test_simple_modeladmin.py
+++ b/wagtail_modeladmin/test/tests/test_simple_modeladmin.py
@@ -1190,24 +1190,48 @@ There are no default tabs on non-Page models so there will be no\
         Publisher.settings_panels = [FieldPanel("name")]
         Publisher.promote_panels = [FieldPanel("headquartered_in")]
 
-        warning_1 = checks.Warning(
-            "Publisher.promote_panels will have no effect on modeladmin editing",
-            hint="""Ensure that Publisher uses `panels` instead of `promote_panels`\
+        warning_1 = (
+            checks.Warning(
+                "Publisher.promote_panels will have no effect on modeladmin editing",
+                hint="""Ensure that Publisher uses `panels` instead of `promote_panels`\
+ or set up an `edit_handler` if you want a tabbed editing interface.
+There are no default tabs on non-Page models so there will be no\
+ Promote tab for the promote_panels to render in.""",
+                obj=Publisher,
+                id="wagtailadmin.W002",
+            )
+            if WAGTAIL_VERSION >= (6, 4)
+            else checks.Warning(
+                "Publisher.promote_panels will have no effect on modeladmin editing",
+                hint="""Ensure that Publisher uses `panels` instead of `promote_panels`\
 or set up an `edit_handler` if you want a tabbed editing interface.
 There are no default tabs on non-Page models so there will be no\
  Promote tab for the promote_panels to render in.""",
-            obj=Publisher,
-            id="wagtailadmin.W002",
+                obj=Publisher,
+                id="wagtailadmin.W002",
+            )
         )
 
-        warning_2 = checks.Warning(
-            "Publisher.settings_panels will have no effect on modeladmin editing",
-            hint="""Ensure that Publisher uses `panels` instead of `settings_panels`\
+        warning_2 = (
+            checks.Warning(
+                "Publisher.settings_panels will have no effect on modeladmin editing",
+                hint="""Ensure that Publisher uses `panels` instead of `settings_panels`\
+ or set up an `edit_handler` if you want a tabbed editing interface.
+There are no default tabs on non-Page models so there will be no\
+ Settings tab for the settings_panels to render in.""",
+                obj=Publisher,
+                id="wagtailadmin.W002",
+            )
+            if WAGTAIL_VERSION >= (6, 4)
+            else checks.Warning(
+                "Publisher.settings_panels will have no effect on modeladmin editing",
+                hint="""Ensure that Publisher uses `panels` instead of `settings_panels`\
 or set up an `edit_handler` if you want a tabbed editing interface.
 There are no default tabs on non-Page models so there will be no\
  Settings tab for the settings_panels to render in.""",
-            obj=Publisher,
-            id="wagtailadmin.W002",
+                obj=Publisher,
+                id="wagtailadmin.W002",
+            )
         )
 
         checks_results = self.get_checks_result()


### PR DESCRIPTION
Replaces #48 -  thank you @nickmoreton 

I've added a commit to fix #50 and did some cleanup.

- Cleanup tox matrix specifiers – I recommend dropping the dots in version numbers as they are a tad noisy and don't add value
- No sense in testing against development versions of Django/Wagtail when they may not even be compatible with other dependencies specified in the matrix
- Testing against development versions of Django/Wagtail is important, continue doing that as part of a 'future' tox environment not executed by default (as to not cause confusion when something breaks upstream)