### PR TITLE
Drop support for Wagtail 6.2 and older

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.3.0] - [UNRELEASED]
 
-- Nothing yet
+- Drop support for Wagtail 5.2, 6.0, 6.1 and 6.2
 
 ## [2.2.0] - 2025-04-25
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ This package is in maintenance mode and will not receive new features. Consider 
 
 ## Supported versions
 
-- Python 3.8 (Wagtail 5.2 only), 3.9, 3.10, 3.11, 3.12, 3.13
+- Python 3.9, 3.10, 3.11, 3.12, 3.13
 - Django 4.2, 5.0, 5.1, 5.2
-- Wagtail 5.2, 6.1, 6.2, 6.3, 6.4 and 7.0
+- Wagtail 6.3, 6.4 and 7.0
 
 ## Installation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,14 +26,13 @@ classifiers = [
     "Framework :: Django :: 5.1",
     "Framework :: Django :: 5.2",
     "Framework :: Wagtail",
-    "Framework :: Wagtail :: 5",
     "Framework :: Wagtail :: 6",
     "Framework :: Wagtail :: 7",
 ]
 dynamic = ["version"]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
-    "Wagtail>=5.2"  # Completely drop Python 3.8 support when we bump this to 6.3
+    "Wagtail>=6.3"
 ]
 [project.optional-dependencies]
 testing = [

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,6 @@
 [tox]
 minversion = 4.18.1
 envlist =
-    py{39,310,311,312}-django42-wagtail52
-    py{310,311,312}-django50-wagtail52
     py{39,310,311,312}-django42-wagtail{63,64,70}
     py{310,311,312}-django50-wagtail{63,64,70}
     ; 6.3, 6.4 and 7.0 work with Django 5.1
@@ -29,9 +27,6 @@ deps =
     django51: Django>=5.1,<5.2
     django52: Django>=5.2,<5.3
 
-    wagtail52: wagtail>=5.2,<6.0
-    wagtail61: wagtail>=6.1,<6.2
-    wagtail62: wagtail>=6.2,<6.3
     wagtail63: wagtail>=6.3,<6.4
     wagtail64: wagtail>=6.4,<6.5
     wagtail70: wagtail>=7.0rc1,<7.1


### PR DESCRIPTION
Wagtail 5.2 LTS goes out of support in less than two weeks. 6.0, 6.1 and 6.2 are already no longer supported.