### PR TITLE
Fix ad-hoc filter support for Django 5

### DIFF
--- a/wagtail_modeladmin/test/tests/test_page_modeladmin.py
+++ b/wagtail_modeladmin/test/tests/test_page_modeladmin.py
@@ -45,18 +45,12 @@ class TestIndexView(WagtailTestUtils, TestCase):
 
         self.assertEqual(response.status_code, 200)
 
-        if DJANGO_VERSION >= (5, 0):
-            # Multi-valued query parameters are supported as of
-            # https://github.com/django/django/pull/16621
-            # Should return both public and private events
-            self.assertEqual(response.context["result_count"], 4)
-            for eventpage in response.context["object_list"]:
-                self.assertIn(eventpage.audience, ["public", "private"])
-        else:
-            # Should use the last value, thus only return private events
-            self.assertEqual(response.context["result_count"], 1)
-            for eventpage in response.context["object_list"]:
-                self.assertEqual(eventpage.audience, "private")
+        # Multi-valued query parameters are supported as of
+        # https://github.com/django/django/pull/16621
+        # Should return both public and private events
+        self.assertEqual(response.context["result_count"], 4)
+        for eventpage in response.context["object_list"]:
+            self.assertIn(eventpage.audience, ["public", "private"])
 
     def test_ad_hoc_filter(self):
         # Filter by location, which is not an option defined in `list_filter`

--- a/wagtail_modeladmin/test/tests/test_page_modeladmin.py
+++ b/wagtail_modeladmin/test/tests/test_page_modeladmin.py
@@ -58,6 +58,35 @@ class TestIndexView(WagtailTestUtils, TestCase):
             for eventpage in response.context["object_list"]:
                 self.assertEqual(eventpage.audience, "private")
 
+    def test_ad_hoc_filter(self):
+        # Filter by location, which is not an option defined in `list_filter`
+        response = self.get(location="Hobart")
+
+        self.assertEqual(response.status_code, 200)
+
+        self.assertEqual(response.context["result_count"], 1)
+        for eventpage in response.context["object_list"]:
+            self.assertEqual(eventpage.location, "Hobart")
+
+    def test_ad_hoc_filter_multivalue(self):
+        # Filter by location, which is not an option defined in `list_filter`
+        response = self.get(location=["The North Pole", "Hobart"])
+
+        self.assertEqual(response.status_code, 200)
+
+        if DJANGO_VERSION >= (5, 0):
+            # Multi-valued query parameters are supported as of
+            # https://github.com/django/django/pull/16621
+            # Should return both The North Pole and Hobart locations
+            self.assertEqual(response.context["result_count"], 2)
+            for eventpage in response.context["object_list"]:
+                self.assertIn(eventpage.location, ["The North Pole", "Hobart"])
+        else:
+            # Should use the last value
+            self.assertEqual(response.context["result_count"], 1)
+            for eventpage in response.context["object_list"]:
+                self.assertEqual(eventpage.location, "Hobart")
+
     def test_search(self):
         response = self.get(q="Someone")
 

--- a/wagtail_modeladmin/views.py
+++ b/wagtail_modeladmin/views.py
@@ -27,7 +27,6 @@ from django.db import models, transaction
 from django.db.models.fields.related import ManyToManyField, OneToOneRel
 from django.shortcuts import get_object_or_404, redirect
 from django.template.defaultfilters import filesizeformat
-from django.utils.datastructures import MultiValueDict
 from django.utils.decorators import method_decorator
 from django.utils.encoding import force_str
 from django.utils.functional import cached_property
@@ -422,12 +421,9 @@ class IndexView(SpreadsheetExportMixin, WMABaseView):
         """
         if not params:
             params = self.params
-        if DJANGO_VERSION >= (5, 0) and isinstance(params, MultiValueDict):
-            # .items() may be called on lookup_params, and MultiValueDict.items() does
-            # not preserve values lists, so make this a dict.
-            lookup_params = dict(params.lists())
-        else:
-            lookup_params = params.copy()  # a dictionary of the query string
+        # .items() may be called on lookup_params, and MultiValueDict.items() does
+        # not preserve values lists, so make this a dict.
+        lookup_params = dict(params.lists())
         # Remove all the parameters that are globally and systematically
         # ignored.
         for ignored in self.IGNORED_PARAMS:

--- a/wagtail_modeladmin/views.py
+++ b/wagtail_modeladmin/views.py
@@ -27,6 +27,7 @@ from django.db import models, transaction
 from django.db.models.fields.related import ManyToManyField, OneToOneRel
 from django.shortcuts import get_object_or_404, redirect
 from django.template.defaultfilters import filesizeformat
+from django.utils.datastructures import MultiValueDict
 from django.utils.decorators import method_decorator
 from django.utils.encoding import force_str
 from django.utils.functional import cached_property
@@ -421,7 +422,12 @@ class IndexView(SpreadsheetExportMixin, WMABaseView):
         """
         if not params:
             params = self.params
-        lookup_params = params.copy()  # a dictionary of the query string
+        if DJANGO_VERSION >= (5, 0) and isinstance(params, MultiValueDict):
+            # .items() may be called on lookup_params, and MultiValueDict.items() does
+            # not preserve values lists, so make this a dict.
+            lookup_params = dict(params.lists())
+        else:
+            lookup_params = params.copy()  # a dictionary of the query string
         # Remove all the parameters that are globally and systematically
         # ignored.
         for ignored in self.IGNORED_PARAMS:


### PR DESCRIPTION
Ad-hoc filters (ie, those not declared in `list_filter`) is broken when using Django 5+. 

Such filtering is supported when using Django 4x (also, it's supported by current Django 5+ ModelAdmin).  

The issue is that we are passing around a `QueryDict` of query params in `IndexView`, and in some places calling `.items()` on it, which has a flattening affect on values. 

This means that, for an undeclared query param:
- the `get_filters` method returns only the last value for a multi-value query, and
- the `get_queryset` passes a `dict[str, str]` to `build_q_object_from_lookup_parameters` Django util, which treats the value part of `.items()` as a list. 

The latter means that a string value gets treated as a list that is OR'd: 
E.g. given a query param: `location=Hobart`, we get a queryset with `WHERE location='H' OR location='o' OR location='b'`...  

The tests that accompanied support for multi-valued query params did not capture this because the filter being tested is declared in `list_filter`. https://github.com/wagtail/wagtail/pull/10242  