### PR TITLE
Fix legacy pagination display when Wagtail >= 7

### DIFF
--- a/wagtail_modeladmin/static/wagtail_modeladmin/css/modeladmin.css
+++ b/wagtail_modeladmin/static/wagtail_modeladmin/css/modeladmin.css
@@ -132,6 +132,15 @@
 
 .modeladmin .pagination ul {
   margin-top: -1.25em;
+  display: block;
+}
+
+.modeladmin .pagination ul .prev {
+  float: inline-start;
+}
+
+.modeladmin .pagination ul .next {
+  float: inline-end;
 }
 
 .modeladmin p.no-results {


### PR DESCRIPTION
Adds `modeladmin` specific CSS selectors rather than relying on the Wagtail ones. 
The Wagtail 7 changes have affected the way the legacy pagination displays.

Before:
![image](https://github.com/user-attachments/assets/2c5b91f1-f88d-4a89-86db-8b2f7ccc1c4a)

After:
![image](https://github.com/user-attachments/assets/a250bfa0-0dbc-4b68-9e6b-6e16efc26ed7)

I'm a +1 for https://github.com/wagtail-nest/wagtail-modeladmin/pull/54, but if this project is strictly maintenance mode, then this fixes the current display issues. 

The CSS changes do not upset the pagination display when Wagtail < 7. 