### PR TITLE
Add Wagtail 7.4 to test matrix

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,10 @@
 minversion = 4.18.1
 envlist =
     ; Django 5.2, supported Wagtail versions (LTS + latest)
-    py{310,311,312,313}-django52-wagtail{70,73}
+    py{310,311,312,313}-django52-wagtail{70,73,74}
     ; Django 6.0, supported Wagtail versions (Django 6.0 support was added in Wagtail 7.3)
-    py{310,311,312,313,314}-django60-wagtail73
+    py{312,313,314}-django60-wagtail{73,74}
+
 
 [testenv]
 extras = testing
@@ -21,9 +22,11 @@ deps =
     coverage
 
     django52: Django>=5.2,<5.3
+    django60: Django>=6.0,<6.1
 
     wagtail70: wagtail>=7.0,<7.1
     wagtail73: wagtail>=7.3,<7.4
+    wagtail74: wagtail>=7.4rc1,<7.5
 
 
 [testenv:future]


### PR DESCRIPTION
Adds Wagtail 7.4 to the tox test matrix (under Django 5.2 and 6.0), and pins django60 to Django>=6.0,<6.1.
Also drops py310/311 from the Django 6.0 matrix since those version combinations aren't supported.